### PR TITLE
Fixes

### DIFF
--- a/defaults/main/apcupsd.yml
+++ b/defaults/main/apcupsd.yml
@@ -13,7 +13,7 @@ fp_apcupsd_upsname: UPS01
 fp_apcupsd_upscable: usb
 fp_apcupsd_upstype: usb
 fp_apcupsd_lockfile: /var/spool/lock
-fp_apcupsd_scriptdir: /usrlocal/etc/apcupsd
+fp_apcupsd_scriptdir: /usr/local/etc/apcupsd
 fp_apcupsd_pwrfaildir: /var/run
 fp_apcupsd_nologindir: /var/run
 fp_apcupsd_onbatterydelay: 6

--- a/defaults/main/ntpdate.yml
+++ b/defaults/main/ntpdate.yml
@@ -12,6 +12,6 @@ fp_ntpdate_flags: -b
 # Sync time on ntpd startup
 fp_ntpd_sync_on_start: 'YES'
 fp_ntpdate_rcconf:
-  - {key: ntpdate_enable, value: '"{{ fp_ntpdate_enable }}"'}
-  - {key: ntpdate_flags, value: '"{{ fp_ntpdate_flags }}"'}
-  - {key: ntpd_sync_on_start, value: '"{{ fp_ntpd_sync_on_start }}"'}
+  - {key: ntpdate_enable, value: "{{ fp_ntpdate_enable }}"}
+  - {key: ntpdate_flags, value: "{{ fp_ntpdate_flags }}"}
+  - {key: ntpd_sync_on_start, value: "{{ fp_ntpd_sync_on_start }}"}


### PR DESCRIPTION
Two more minor typos I found in the devel branch.

Also not sure how to handle this but the ntpdate service is a run once service, so everytime ansible is run, it wants to restart it. i.e if you do `service ntpdate start; service ntpdate status` the status will say not running.